### PR TITLE
Remove "Depends:" field from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Description: The ANU Quantum Random Number Generator provided by the Australian 
 License: GPL-2 | file LICENSE
 Imports: curl, jsonlite, methods, Rmpfr, utils
 Suggests: testthat
-Depends: R (>= 3.5)
 Encoding: UTF-8
 LazyData: true
 URL: https://qrng.anu.edu.au/index.php


### PR DESCRIPTION
## Description
Removed "Depends:" field from DESCRIPTION to allow installation on R < 3.5.

## Motivation and Context
The dependency on R >= 3.5 seemed excessive to me. [A few months ago I did some asking around](https://community.rstudio.com/t/determining-which-version-of-r-to-depend-on/4396) on what the recommended approach on R version dependency is, and [Hadley summarized it as follows:](https://community.rstudio.com/t/determining-which-version-of-r-to-depend-on/4396/10)

> Now, I think you should only explicitly require an R version under two circumstances:
> - You are required to by R CMD check
> - You have checked that your package works on multiple versions of R and you want to assert that. (This is now easy on travis)

## How Has This Been Tested?
I have executed R CMD check and all tests locally after removing the DESCRIPTION field and everything still passed.  
It would be fairly easy to add `oldrel` or earlier versions to your `.travis.yml` and see what happens. Putting the dependency back in is always possible anyway, the idea is to only depend on the "real" minimum R version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(Non of these apply, depending on what is considered an "issue" or "functionality")

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
